### PR TITLE
fixed confusing instructions

### DIFF
--- a/07_classes_objects_methods/07_03_freeform.py
+++ b/07_classes_objects_methods/07_03_freeform.py
@@ -1,13 +1,9 @@
 '''
 - Write a script with three classes that model everyday objects.
-- Each class should have an __init__ method that sets attributes
-    to a default value if values are not passed.
+- Each class should have an __init__ method that sets at least three attributes
 - Create at least two objects of each class using the __init__ method.
-- Each object should have at least three attributes.
-- Each class should have at least two class attributes.
-- Create a print method in each class that prints out the attributes
+- Include a __str__ method in each class that prints out the attributes
     in a nicely formatted string.
-- Include a __str__ method in each class.
 - Overload the __add__ method in one of the classes so that it's possible
     to add attributes of two instances of that class using the + operator.
 - Once the objects are created, change some of the attribute values.
@@ -15,6 +11,5 @@
 Be creative. Have some fun. :)
 Using objects you can model anything you want.
 Cars, animals, poker games, sports teams, trees, beers, people etc...
-
 
 '''


### PR DESCRIPTION
changes made:

OLD: - `Each class should have an __init__ method that sets attributes
    to a default value if values are not passed.  `
This is confusing because you don't _need_ to have default values, you could have required values as well.

OLD: `- Each object should have at least three attributes.` -- this line removed
OLD: `- Each class should have at least two class attributes.`  -- this line removed. I don't believe that we are asking for class attributes? did we mean instance attributes? 

OLD: `Include a __str__ method in each class` combined with "create a print method" because that line of instruction seemed to be the same as the next line

I'm making this as a pull request because I'm not sure I understood the instructions myself entirely.
Did we want 3 instance attributes and 2 class attributes?
so 5 attributes total? 2 of which would be like

```
class car()
    thing = 0
    thing_ =1
    def __init__(self, thing1, thing2, thing3):
         self.thing1=thing1
         self.thing2=thing2
         self.thing3 = thing3
```
because that's technically what the instructions are currently asking for.
Let me know